### PR TITLE
build: use --export-png to support Inkscape 0.9.x

### DIFF
--- a/logos/Makefile
+++ b/logos/Makefile
@@ -15,29 +15,28 @@ svg/%.svg : src/%.svg
 	inkscape $< --vacuum-defs --export-plain-svg=$@
 
 png_1x/%.png : src/%.svg
-	inkscape $< --export-dpi 96 -o $@
+	inkscape $< --export-dpi 96 --export-png=$@
 
 png_2x/%.png : src/%.svg
-	inkscape $< --export-dpi 192 -o $@
+	inkscape $< --export-dpi 192 --export-png=$@
 
 png_256/%.png : src/%.svg
-	inkscape $< --export-width 256 -o $@
+	inkscape $< --export-width 256 --export-png=$@
 
 png_128/%.png : src/%.svg
-	inkscape $< --export-width 128 -o $@
+	inkscape $< --export-width 128 --export-png=$@
 
 png_64/%.png : src/%.svg
-	inkscape $< --export-width 64 -o $@
+	inkscape $< --export-width 64 --export-png=$@
 
 png_32/%.png : src/%.svg
-	inkscape $< --export-width 32 -o $@
+	inkscape $< --export-width 32 --export-png=$@
 
 png_16/%.png : src/%.svg
-	inkscape $< --export-width 16 -o $@
+	inkscape $< --export-width 16 --export-png $@
 
 boot_logo.ppm: src/AsahiLinux_logomark.svg
 	inkscape src/AsahiLinux_logomark.svg --export-area=24:24:550:550 \
-		--export-width 80 --export-type=png \
-		--export-background=black -o - | \
+		--export-width 80 --export-background=black \
+		--export-png=- | \
 		pngtopnm | ppmquant 224 | pnmtoplainpnm > $@
-


### PR DESCRIPTION
Older Inkscape versions do not have -o, only -e/--export-png.
Inkscape 1.x seems to have removed -e, but [retained --export-* for backwards compatibility](https://gitlab.com/inkscape/inkscape/-/blob/INKSCAPE_1_0_1/src/inkscape-main.cpp#L153)