### PR TITLE
Mark SVG files as linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.svg linguist-detectable


### PR DESCRIPTION
This looks a bit nicer in the repo's language bar:

![image](https://user-images.githubusercontent.com/30873659/161309298-b1f7955c-b961-4f5b-b642-6e3560611dcd.png)
